### PR TITLE
Fix css:watch npm script typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "gulp",
     "commit": "npx git-cz",
     "semantic-release": "semantic-release",
-    "css": "postcss src/css/nakDS.css -o docs/css/nakDS.min.css & npm run tokens",
+    "css": "postcss src/css/nakDS.css -o docs/css/nakDS.min.css && npm run tokens",
     "tokens": "postcss src/css/tokens/tokens.css -o docs/css/nakDS.tokens.css",
     "css:watch": "postcss src/css/nakDS.css -o docs/css/nakDS.min.css --watch"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "semantic-release": "semantic-release",
     "css": "postcss src/css/nakDS.css -o docs/css/nakDS.min.css & npm run tokens",
     "tokens": "postcss src/css/tokens/tokens.css -o docs/css/nakDS.tokens.css",
-    "css:watch": "postcss src/css/nakDS.css -o docs/css/nakDS.min.css —watch"
+    "css:watch": "postcss src/css/nakDS.css -o docs/css/nakDS.min.css --watch"
   },
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## In this Pull Request

- [x] Added `&` forgotten to concatenate commands in  npm scripts
- [x] Fixed a typo in the `css:watch` npm script

> In the postcss-cli the option to watch the change in the css files is `-w` (one slash), or `--watch` (two slashes)

### PostCSS CLI documentation

[Usage](https://github.com/postcss/postcss-cli#usage)

```
Usage:
  postcss [input.css] [OPTIONS] [-o|--output output.css] [--watch|-w]
  
Basic options:
  ...
  -w, --watch    Watch files for changes and recompile as needed       [boolean]
```